### PR TITLE
Fixes typos for `network activity` related text fields

### DIFF
--- a/Netiquette/Preferences.xib
+++ b/Netiquette/Preferences.xib
@@ -141,7 +141,7 @@
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="471" translatesAutoresizingMaskIntoConstraints="NO" id="AAL-QY-azK">
                     <rect key="frame" x="72" y="84" width="522" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Do not display network activty from to system binaries" id="SYJ-Qv-cRq">
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Do not display network activity from to system binaries" id="SYJ-Qv-cRq">
                         <font key="font" size="13" name="Menlo-Regular"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="471" translatesAutoresizingMaskIntoConstraints="NO" id="h0F-s7-Sm3">
                     <rect key="frame" x="72" y="29" width="522" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Do not display network activty to local host (lo*)" id="WTz-7B-Wrc">
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Do not display network activity to local host (lo*)" id="WTz-7B-Wrc">
                         <font key="font" size="13" name="Menlo-Regular"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
Hi,

I've found two little typos in the help text descriptions.