### PR TITLE
Fix null pointer dereference crash in Event.m that occurred if the keys ys kNStatSrcKeyLocal or kNStatSrcKeyRemote were not set

### DIFF
--- a/Netiquette/Event.m
+++ b/Netiquette/Event.m
@@ -66,11 +66,17 @@
         self.tcpState = event[kNStatSrcKeyTCPState];
         
         //convert local address
-        self.localAddress = [self parseAddress:event[kNStatSrcKeyLocal]];
+        if(event[kNStatSrcKeyLocal])
+        {
+            self.localAddress = [self parseAddress:event[kNStatSrcKeyLocal]];
+        }
         
         //convert remote address
         // and resolve remote name if necessary
-        self.remoteAddress = [self parseAddress:event[kNStatSrcKeyRemote]];
+        if(event[kNStatSrcKeyRemote])
+        {
+            self.remoteAddress = [self parseAddress:event[kNStatSrcKeyRemote]];
+        }
         
         //in background
         // resolve host name
@@ -85,14 +91,20 @@
                 NSString* remoteName = nil;
                 
                 //resolve /save local
-                localName = [self resolveName:(struct sockaddr *)[(NSData*)(event[kNStatSrcKeyLocal]) bytes]];
+                if(event[kNStatSrcKeyLocal])
+                {
+                    localName = [self resolveName:(struct sockaddr *)[(NSData*)(event[kNStatSrcKeyLocal]) bytes]];
+                }
                 if(0 != localName.length)
                 {
                     self.localAddress[KEY_HOST_NAME] = localName;
                 }
                 
                 //resolve / save remove
-                remoteName = [self resolveName:(struct sockaddr *)[(NSData*)(event[kNStatSrcKeyRemote]) bytes]];
+                if(event[kNStatSrcKeyRemote])
+                {
+                    remoteName = [self resolveName:(struct sockaddr *)[(NSData*)(event[kNStatSrcKeyRemote]) bytes]];
+                }
                 if(0 != remoteName.length)
                 {
                     self.remoteAddress[KEY_HOST_NAME] = remoteName;


### PR DESCRIPTION
I had a problem with Netiquette recently where it would just crash as soon as it started up. Deleting the cache and preferences had no effect.

So I tried building the source code, and found the culprit: my Notes app had a UDP connection on an obscure interface (called "utun2") that, for whatever reason, didn't have a local IP address on it. Specifically, the event looked like this:
```
(lldb) po event
{
    ChannelArchitecture = 1;
    durationAbsoluteTime = 6274373086189;
    epid = 75131;
    eupid = 0;
    euuid = "4DBEC6BC-C61D-3D0B-BD89-460D0A95CA0E";
    fuuid = "465B663B-39B7-4785-A7EF-FBB920C0885D";
    ifUnknown = 1;
    interface = 24;
    processID = 75131;
    processName = Notes;
    provider = UDP;
    receiveBufferSize = 0;
    receiveBufferUsed = 0;
    remoteAddress = {length = 16, bytes = 0x10020bd6000000000000000000000000};
    rttAverage = 0;
    rttMinimum = 0;
    rttVariation = 0;
    rxBytes = 0;
    rxCellularBytes = 0;
    rxPackets = 0;
    rxWiFiBytes = 0;
    rxWiredBytes = 0;
    startAbsoluteTime = 15101039181963;
    trafficClass = 0;
    txBytes = 0;
    txCellularBytes = 0;
    txPackets = 0;
    txWiFiBytes = 0;
    txWiredBytes = 0;
    uniqueProcessID = 1857835;
    uuid = "4DBEC6BC-C61D-3D0B-BD89-460D0A95CA0E";
}
```
I can't reproduce the problem after quitting and relaunching Notes, so I'm not sure what causes Notes to open that odd UDP connection. But if it happens again, my change fixes Netiquette so it won't crash if the local address for some connection isn't set for whatever reason.